### PR TITLE
Fix autohide behaviour

### DIFF
--- a/js/jquery.lionbars.0.3.js
+++ b/js/jquery.lionbars.0.3.js
@@ -94,7 +94,9 @@
 		});
 		$(document).mouseup(function(e) {
 			if (HDragging || VDragging) {
-				activeWrap.parent().find('.lb-v-scrollbar, .lb-h-scrollbar').fadeOut(150);
+				if (autohide) {
+					activeWrap.parent().find('.lb-v-scrollbar, .lb-h-scrollbar').fadeOut(150);
+				}
 				if (VDragging) {
 					VDragging = false;
 				}


### PR DESCRIPTION
When autohide option is false, the jQuery fadeOut still triggers... but never come back.
